### PR TITLE
Item B-03526: As a Manager, I wold like to sort services in the servi…

### DIFF
--- a/src/main/java/edu/tamu/app/controller/ServiceController.java
+++ b/src/main/java/edu/tamu/app/controller/ServiceController.java
@@ -17,6 +17,7 @@ import edu.tamu.app.model.Idea;
 import edu.tamu.app.model.Service;
 import edu.tamu.app.model.repo.IdeaRepo;
 import edu.tamu.app.model.repo.ServiceRepo;
+import edu.tamu.app.model.request.FilteredPageRequest;
 import edu.tamu.app.model.request.IssueRequest;
 import edu.tamu.app.model.request.ServiceRequest;
 import edu.tamu.app.service.ProjectService;
@@ -50,6 +51,12 @@ public class ServiceController {
     @PreAuthorize("hasRole('ANONYMOUS')")
     public ApiResponse getPublicServices() {
         return new ApiResponse(SUCCESS, serviceRepo.findByIsPublicOrderByStatusDescNameAsc(true));
+    }
+
+    @RequestMapping("/page")
+    @PreAuthorize("hasRole('ANONYMOUS')")
+    public ApiResponse page(@RequestBody FilteredPageRequest filteredPageRequest) {
+        return new ApiResponse(SUCCESS, serviceRepo.findAll(filteredPageRequest.getServiceSpecification(), filteredPageRequest.getPageRequest()));
     }
 
     @RequestMapping("/{id}")

--- a/src/main/java/edu/tamu/app/model/repo/ServiceRepo.java
+++ b/src/main/java/edu/tamu/app/model/repo/ServiceRepo.java
@@ -2,6 +2,9 @@ package edu.tamu.app.model.repo;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import edu.tamu.app.enums.Status;
@@ -9,6 +12,8 @@ import edu.tamu.app.model.Service;
 import edu.tamu.app.model.repo.custom.ServiceRepoCustom;
 
 public interface ServiceRepo extends JpaRepository<Service, Long>, ServiceRepoCustom {
+
+    public Page<Service> findAll(Specification<Service> specification, Pageable pageable);
 
     public List<Service> findByIsPublicOrderByStatusDescNameAsc(Boolean isPublic);
 

--- a/src/main/java/edu/tamu/app/model/repo/specification/AbstractSpecification.java
+++ b/src/main/java/edu/tamu/app/model/repo/specification/AbstractSpecification.java
@@ -49,9 +49,16 @@ public abstract class AbstractSpecification<E> implements Specification<E> {
             }
         }
 
-        query.orderBy(cb.desc(root.get("lastModified")));
+        toPredicateDefaultQueryOrderBy(root, query, cb);
 
         return builder.build(cb);
+    }
+
+    /**
+     * Allow implementing classes to control order by in case lastModified is non-existent.
+     */
+    protected void toPredicateDefaultQueryOrderBy(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+        query.orderBy(cb.desc(root.get("lastModified")));
     }
 
     private class PredicateBuilder {

--- a/src/main/java/edu/tamu/app/model/repo/specification/ServiceSpecification.java
+++ b/src/main/java/edu/tamu/app/model/repo/specification/ServiceSpecification.java
@@ -1,0 +1,19 @@
+package edu.tamu.app.model.repo.specification;
+
+import java.util.Map;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+public class ServiceSpecification<E> extends AbstractSpecification<E> {
+
+    public ServiceSpecification(Map<String, String[]> filters) {
+        super(filters);
+    }
+
+    @Override
+    protected void toPredicateDefaultQueryOrderBy(Root<E> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+        query.orderBy(cb.desc(root.get("name")));
+    }
+}

--- a/src/main/java/edu/tamu/app/model/request/FilteredPageRequest.java
+++ b/src/main/java/edu/tamu/app/model/request/FilteredPageRequest.java
@@ -13,9 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.tamu.app.model.FeatureProposal;
 import edu.tamu.app.model.Idea;
 import edu.tamu.app.model.Note;
+import edu.tamu.app.model.Service;
 import edu.tamu.app.model.repo.specification.FeatureProposalSpecification;
 import edu.tamu.app.model.repo.specification.IdeaSpecification;
 import edu.tamu.app.model.repo.specification.NoteSpecification;
+import edu.tamu.app.model.repo.specification.ServiceSpecification;
 
 public class FilteredPageRequest {
 
@@ -40,6 +42,11 @@ public class FilteredPageRequest {
     @JsonIgnore
     public IdeaSpecification<Idea> getIdeaSpecification() {
         return new IdeaSpecification<Idea>(filters);
+    }
+
+    @JsonIgnore
+    public ServiceSpecification<Service> getServiceSpecification() {
+        return new ServiceSpecification<Service>(filters);
     }
 
     @JsonIgnore


### PR DESCRIPTION
…ce management table

The ServiceSpecification is implemented to provide sorting and pagination.

The AbstracSpecification used a default 'lastModified' order by, which does not exist in the ServiceRepo.
To prevent breakage, the the order by assignment was move into its own function, toPredicateDefaultQueryOrderBy().
This allows for the ServiceSpecification, as an exception, to not attempt to order by "lastModified" by overriding that new method.