### PR TITLE
Travis-CI ends up with DEBUG logs when default is set to INFO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
       <exclusions>
-          <exclusion>
-              <groupId>org.springframework.boot</groupId>
-              <artifactId>spring-boot-starter-logging</artifactId>
-          </exclusion>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,17 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
+      <exclusions>
+          <exclusion>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-starter-logging</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The logback logger ends up getting included by spring-boot-starter-logging during org.springframework.boot.

Exclude spring-boot-starter-logging and manually include spring-boot-starter-log4j2.