### PR TITLE
Issue 173: Provide confirmation after submitting idea or issue

### DIFF
--- a/src/main/java/edu/tamu/app/controller/ServiceController.java
+++ b/src/main/java/edu/tamu/app/controller/ServiceController.java
@@ -94,7 +94,11 @@ public class ServiceController {
         Service service = serviceRepo.findOne(request.getService());
         issueRequest.setService(service.getName());
         issueRequest.setCredentials(credentials);
-        return productService.submitIssueRequest(issueRequest);
+        ApiResponse response = productService.submitIssueRequest(issueRequest);
+        if (response.getMeta().getStatus().equals(ApiStatus.SUCCESS)) {
+            return new ApiResponse(SUCCESS, String.format("Your issue for %s has been submitted!", service.getName()), response.getPayload());
+        }
+        return response;
     }
 
     @RequestMapping("/feature")
@@ -104,7 +108,7 @@ public class ServiceController {
         Idea idea = new Idea(request);
         idea.setService(service);
         ideaRepo.create(idea, credentials);
-        return new ApiResponse(ApiStatus.SUCCESS, "Your feature request for " + service.getName() + " has been submitted as an idea!");
+        return new ApiResponse(ApiStatus.SUCCESS, String.format("Your feature request for %s has been submitted as an idea!", service.getName()));
     }
 
 }

--- a/src/test/java/edu/tamu/app/controller/ServiceControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/ServiceControllerTest.java
@@ -192,7 +192,7 @@ public class ServiceControllerTest {
         ServiceRequest request = new ServiceRequest(AbstractRequest.RequestType.ISSUE, "Test feature request", "This is a test issue request on product 1", 1L);
         ApiResponse response = serviceController.submitIssueRequest(request, credentials);
         assertEquals("Response was not a success!", ApiStatus.SUCCESS, response.getMeta().getStatus());
-        assertEquals("Response message was not correct!", "Successfully submitted " + request.getType().getName() + " request!", response.getMeta().getMessage());
+        assertEquals("Response message was not correct!", String.format("Your issue for %s has been submitted!", TEST_SERVICE1_NAME), response.getMeta().getMessage());
     }
 
     @Test
@@ -200,7 +200,7 @@ public class ServiceControllerTest {
         ServiceRequest request = new ServiceRequest(AbstractRequest.RequestType.FEATURE, "Test issue request", "This is a test issue request on product 1", 1L);
         ApiResponse response = serviceController.submitFeatureRequest(request, credentials);
         assertEquals("Response was not a success!", ApiStatus.SUCCESS, response.getMeta().getStatus());
-        assertEquals("Response message was not correct!", "Your feature request for " + TEST_SERVICE1_NAME + " has been submitted as an idea!", response.getMeta().getMessage());
+        assertEquals("Response message was not correct!", String.format("Your feature request for %s has been submitted as an idea!", TEST_SERVICE1_NAME), response.getMeta().getMessage());
     }
 
     @After


### PR DESCRIPTION
The `submitFeatureRequest()` has a message but `submitIssueRequest()` needs one.

Also update to using String.format().

Relates TAMULib/LibraryServiceStatusSystemUI#177
Resolves TAMULib/LibraryServiceStatusSystemUI#173