### PR TITLE
Spring migration broke Web Sockets due to setAllowedOrigins behavioral change.

### DIFF
--- a/src/main/java/edu/tamu/app/config/AppWebSocketConfig.java
+++ b/src/main/java/edu/tamu/app/config/AppWebSocketConfig.java
@@ -10,7 +10,7 @@ import org.springframework.web.socket.config.annotation.WebSocketTransportRegist
 
 /**
  * Web Socket Configuration.
- * 
+ *
  * @author
  *
  */
@@ -51,7 +51,7 @@ public class AppWebSocketConfig implements WebSocketMessageBrokerConfigurer {
      */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/connect").setAllowedOrigins("*").withSockJS();
+        registry.addEndpoint("/connect").setAllowedOriginPatterns("*").withSockJS();
     }
 
 }


### PR DESCRIPTION
The `setAllowedOrigins()` must now be `setAllowedOriginPatterns()`.